### PR TITLE
Do not support fullscreen on iOS

### DIFF
--- a/src/Youtube.js
+++ b/src/Youtube.js
@@ -619,7 +619,9 @@ THE SOFTWARE. */
     reset: function() {},
 
     supportsFullScreen: function() {
-      return true;
+      return document.webkitFullscreenEnabled ||
+        document.mozFullScreenEnabled ||
+        document.msFullscreenEnabled;
     },
 
     // Tries to get the highest resolution thumbnail available for the video


### PR DESCRIPTION
Crossposted: https://github.com/videojs/videojs-youtube/pull/458 (videojs-youtube repo)

The current implementation of supportsFullScreen is just returning true (https://github.com/videojs/videojs-youtube/blob/master/src/Youtube.js#L621-L623), which seems to be not functioning well in iOS.

In order to fall back to full window mode in videoJS, I've made some changes to check three vendor fullscreen methods.